### PR TITLE
Fix session duplication in global view

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -134,8 +133,8 @@ func runClean(cmd *cobra.Command, args []string) error {
 		}
 	}
 	
-	// Save updated sessions back to their respective locations
-	if err := saveSessionsToTheirRepositories(activeSessions); err != nil {
+	// Save updated sessions back to global location
+	if err := config.SaveSessions(activeSessions); err != nil {
 		fmt.Printf("Warning: failed to save updated sessions: %v\n", err)
 	}
 	
@@ -154,38 +153,3 @@ func removeWorktreeDirectory(worktreePath string) error {
 	return os.RemoveAll(worktreePath)
 }
 
-// saveSessionsToTheirRepositories saves sessions back to their appropriate locations
-func saveSessionsToTheirRepositories(sessions []config.SessionMetadata) error {
-	// Group sessions by repository
-	sessionsByRepo := make(map[string][]config.SessionMetadata)
-	var globalSessions []config.SessionMetadata
-	
-	for _, session := range sessions {
-		if session.RepositoryRoot != "" {
-			// Repository-specific session
-			key := session.RepositoryRoot
-			sessionsByRepo[key] = append(sessionsByRepo[key], session)
-		} else {
-			// Global session (backward compatibility)
-			globalSessions = append(globalSessions, session)
-		}
-	}
-	
-	// Save global sessions
-	if len(globalSessions) > 0 {
-		if err := config.SaveSessions(globalSessions); err != nil {
-			return err
-		}
-	}
-	
-	// Save repository-specific sessions
-	for repoRoot, repoSessions := range sessionsByRepo {
-		sessionsPath := filepath.Join(repoRoot, ".sbs", "sessions.json")
-		if err := config.SaveSessionsToPath(repoSessions, sessionsPath); err != nil {
-			// Don't fail completely if one repository fails
-			fmt.Printf("Warning: failed to save sessions for repository %s: %v\n", repoRoot, err)
-		}
-	}
-	
-	return nil
-}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -55,9 +55,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 	tmuxManager := tmux.NewManager()
 	issueTracker := issue.NewTracker(cfg)
 	
-	// Load repository-specific sessions
-	sessionsPath := currentRepo.GetSessionsPath()
-	sessions, err := config.LoadSessionsFromPath(sessionsPath)
+	// Load global sessions
+	sessions, err := config.LoadSessions()
 	if err != nil {
 		return fmt.Errorf("failed to load sessions: %w", err)
 	}
@@ -137,8 +136,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 		sessions = append(sessions, *sessionMetadata)
 	}
 	
-	// Save updated sessions to repository-specific location
-	if err := config.SaveSessionsToPath(sessions, sessionsPath); err != nil {
+	// Save updated sessions to global location
+	if err := config.SaveSessions(sessions); err != nil {
 		return fmt.Errorf("failed to save sessions: %w", err)
 	}
 	

--- a/pkg/repo/manager.go
+++ b/pkg/repo/manager.go
@@ -44,10 +44,6 @@ func (m *Manager) DetectCurrentRepository() (*Repository, error) {
 	}, nil
 }
 
-// GetSessionsPath returns the path to the repository-specific sessions file
-func (r *Repository) GetSessionsPath() string {
-	return filepath.Join(r.Root, ".sbs", "sessions.json")
-}
 
 // GetTmuxSessionName returns the repository-scoped tmux session name
 func (r *Repository) GetTmuxSessionName(issueNumber int) string {


### PR DESCRIPTION
## Summary
- Fixed session duplication issue in global view by consolidating to single source of truth
- Simplified architecture while maintaining all existing functionality
- Repository scoping now works through filtering rather than separate files

## Problem
The global view was showing duplicate sessions because the system loaded from both:
1. Global sessions file (`~/.config/sbs/sessions.json`) 
2. Repository-specific files (`.sbs/sessions.json` in each repo)

Without deduplication logic, sessions appeared twice if they existed in both locations.

## Solution
**Consolidated to single global sessions file as the source of truth:**

- `LoadAllRepositorySessions()` now only loads from global file
- Repository view filters global sessions by `RepositoryRoot` field
- All session creation/updates use global file only
- Removed complex repository discovery and scanning logic

## Technical Changes
- **config.go**: Simplified session loading, removed repository scanning
- **model.go**: Updated TUI to filter global sessions for repository view  
- **start.go**: Changed to load/save from global sessions file
- **clean.go**: Updated to save cleaned sessions to global file only
- **manager.go**: Removed unused `GetSessionsPath()` method

## Benefits
- ✅ Eliminates session duplication in global view
- ✅ Maintains repository scoping functionality through filtering
- ✅ Simplifies codebase by removing ~130 lines of complex logic
- ✅ Single source of truth for session data
- ✅ Backward compatible with existing sessions

## Test Plan
- [x] Build succeeds without errors
- [x] List command works in both plain and TUI modes
- [x] Repository filtering logic updated correctly
- [x] Session creation/cleanup paths updated

🤖 Generated with [Claude Code](https://claude.ai/code)