### PR TITLE
Fix SBS_TITLE environment variable not propagating to sandbox

### DIFF
--- a/work-issue.sh
+++ b/work-issue.sh
@@ -152,9 +152,9 @@ else
   # If SBS_TITLE is not set, try to get it from tmux environment
   # This handles cases where the variable was set via 'tmux set-environment'
   if command -v tmux >/dev/null 2>&1; then
-    TMUX_SBS_TITLE=$(tmux show-environment SBS_TITLE 2>/dev/null | cut -d= -f2- 2>/dev/null || echo "")
-    if [ -n "$TMUX_SBS_TITLE" ]; then
-      export SBS_TITLE="$TMUX_SBS_TITLE"
+    TMUX_OUTPUT=$(tmux show-environment SBS_TITLE 2>/dev/null || echo "")
+    if [[ "$TMUX_OUTPUT" =~ ^SBS_TITLE=(.*)$ ]]; then
+      export SBS_TITLE="${BASH_REMATCH[1]}"
     fi
   fi
 fi

--- a/work-issue.sh
+++ b/work-issue.sh
@@ -143,6 +143,22 @@ update_claude_project_trust
 # Install Claude Code hook in sandbox environment
 install_claude_hook
 
+# Ensure SBS_TITLE environment variable is available to sandbox
+# The tmux session sets this via 'tmux set-environment', but we need to export it
+# so that it's inherited by the sandbox process
+if [ -n "$SBS_TITLE" ]; then
+  export SBS_TITLE
+else
+  # If SBS_TITLE is not set, try to get it from tmux environment
+  # This handles cases where the variable was set via 'tmux set-environment'
+  if command -v tmux >/dev/null 2>&1; then
+    TMUX_SBS_TITLE=$(tmux show-environment SBS_TITLE 2>/dev/null | cut -d= -f2- 2>/dev/null || echo "")
+    if [ -n "$TMUX_SBS_TITLE" ]; then
+      export SBS_TITLE="$TMUX_SBS_TITLE"
+    fi
+  fi
+fi
+
 sandbox \
   --net="host" \
   --bind /tmp/tmux-1000 \


### PR DESCRIPTION
## Summary
- Fixed SBS_TITLE environment variable not being available inside sandbox execution contexts
- Added environment variable propagation logic to work-issue.sh
- Ensures sandbox processes can access friendly issue titles

## Problem
The `SBS_TITLE` environment variable was being set in tmux sessions via `tmux set-environment` but was not being exported to child processes, causing it to be unavailable inside sandbox execution contexts where the work-issue.sh script runs.

## Solution
Added logic to work-issue.sh to:
1. Export SBS_TITLE if already available in shell environment
2. Retrieve and export SBS_TITLE from tmux environment using `tmux show-environment` if needed  
3. Handle cases where tmux is unavailable gracefully

## Test plan
- [x] Verified shell script syntax is correct
- [x] Added comprehensive testing plan in requirements/2025-08-01-issue-20-sbs-title-environment-variable/TESTING-PLAN.md
- [x] Implemented TDD approach with failing tests that demonstrate the issue
- [x] Environment variable now properly propagates to sandbox execution context
- [x] Backward compatibility maintained - existing functionality unaffected

## Changes
- Modified `work-issue.sh` to add environment variable propagation logic
- Added comprehensive testing plan for the fix
- Ensured robust error handling for edge cases

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)